### PR TITLE
Include limits.h

### DIFF
--- a/include/hxcpp.h
+++ b/include/hxcpp.h
@@ -19,6 +19,7 @@
 #endif
 
 // Standard headers ....
+#include <limits>
 
 // Windows hack
 #define NOMINMAX


### PR DESCRIPTION
Fixes an issue where `std::numeric_limits` is unavailable in `Object.h` (and continues the structure of includes being in `hxcpp.h`, not individual files).